### PR TITLE
CASSANDRA-16681 Fix LongBufferPoolTest burn test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2808,7 +2808,7 @@ jobs:
   j8_build:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: medium
+    resource_class: small
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2820,6 +2820,8 @@ jobs:
           id
           echo '*** cat /proc/cpuinfo ***'
           cat /proc/cpuinfo
+          echo '*** nproc ***'
+          nproc
           echo '*** free -m ***'
           free -m
           echo '*** df -m ***'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2808,7 +2808,7 @@ jobs:
   j8_build:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: 2xlarge
+    resource_class: xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2808,7 +2808,7 @@ jobs:
   j8_build:
     docker:
     - image: apache/cassandra-testing-ubuntu2004-java11-w-dependencies:20210304
-    resource_class: small
+    resource_class: 2xlarge
     working_directory: ~/
     shell: /bin/bash -eo pipefail -l
     parallelism: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2822,6 +2822,8 @@ jobs:
           cat /proc/cpuinfo
           echo '*** nproc ***'
           nproc
+          echo '*** cat /sys/fs/cgroup/cpuset/cpuset.cpus ***'
+          cat /sys/fs/cgroup/cpuset/cpuset.cpus
           echo '*** free -m ***'
           free -m
           echo '*** df -m ***'

--- a/test/burn/org/apache/cassandra/utils/memory/LongBufferPoolTest.java
+++ b/test/burn/org/apache/cassandra/utils/memory/LongBufferPoolTest.java
@@ -366,7 +366,7 @@ public class LongBufferPoolTest
                         size = 0;
 
                     // either share to free, or free immediately
-                    if (rand.nextBoolean())
+                    if (rand.nextInt(10) == 0)
                     {
                         shareTo.add(check);
                         freeingSize += size;


### PR DESCRIPTION
Fix LongBufferPoolTest burn test by decreasing the likelihood of getting stuck in an unsatisfiable condition due to randomness.