### PR TITLE
CASSANDRA-16681 Fix flaky LongBufferPoolTest

### DIFF
--- a/test/burn/org/apache/cassandra/utils/memory/LongBufferPoolTest.java
+++ b/test/burn/org/apache/cassandra/utils/memory/LongBufferPoolTest.java
@@ -136,7 +136,7 @@ public class LongBufferPoolTest
     private void testPoolAllocate(boolean recyclePartially) throws InterruptedException, ExecutionException
     {
         BufferPool pool = new BufferPool("test_pool", 16 << 20, recyclePartially);
-        testAllocate(pool, Runtime.getRuntime().availableProcessors() * 2, TimeUnit.MINUTES.toNanos(2L));
+        testAllocate(pool, 16, TimeUnit.MINUTES.toNanos(2L));
     }
 
     private static final class BufferCheck


### PR DESCRIPTION
Fix flaky LongBufferPoolTest by using a static number of threads instead of determining the number of CPU cores at runtime which is not reliable in containerized environments.